### PR TITLE
Fix: Change Arduino Lint action to update.

### DIFF
--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -23,4 +23,4 @@ jobs:
         uses: arduino/arduino-lint-action@v1
         with:
           project-type: library
-          library-manager: submit
+          library-manager: update


### PR DESCRIPTION
This has become necessary because this library has been successfully submitted to the library manager.